### PR TITLE
DHT-5: Modify DHT to allow a custom bucket id function.

### DIFF
--- a/dht.cpp
+++ b/dht.cpp
@@ -116,12 +116,12 @@ DiskHashTable::DiskHashTable()
 {}
 
 bool DiskHashTable::open(
-    const std::string path_name,
-    const std::string base_name,
-    int               level,
-    size_t            key_len,
-    size_t            val_len,
-    dht_hash_func     hash_func
+    const std::string  path_name,
+    const std::string  base_name,
+    int                level,
+    size_t             key_len,
+    size_t             val_len,
+    dht_bucket_id_func bucket_func
 )
 {
     name   = base_name;
@@ -129,7 +129,9 @@ bool DiskHashTable::open(
     vallen = val_len;
     reclen = key_len;
     reccnt = 0;
-    hashfunc = (hash_func == nullptr) ? DiskHashTable::default_hasher : hash_func;
+    buckfunc = (bucket_func == nullptr)
+             ? DiskHashTable::default_hasher
+             : bucket_func;
 
     std::stringstream ss;
     ss << path_name << level << '/' << name << '/';
@@ -143,7 +145,7 @@ DiskHashTable::~DiskHashTable()
 
 std::string DiskHashTable::calc_bucket_id(ucharptr_c key)
 {
-    return hashfunc(key, keylen);
+    return buckfunc(key, keylen);
 }
 
 bool DiskHashTable::search(ucharptr_c key, ucharptr val)

--- a/dht.h
+++ b/dht.h
@@ -23,6 +23,8 @@
 typedef unsigned char * ucharptr;
 typedef const ucharptr  ucharptr_c;
 
+typedef std::string (*dht_hash_func)(ucharptr_c, size_t);
+
 struct BucketFile
 {
     static const char *p_naught;
@@ -54,6 +56,7 @@ private:
     std::string                        path;
     std::string                        name;
     size_t                             reccnt;
+    dht_hash_func                      hashfunc;
 
 public:
     DiskHashTable();
@@ -65,10 +68,10 @@ public:
         const std::string base_name,
         int               level,
         size_t            key_len,
-        size_t            val_len = 0);
+        size_t            val_len = 0,
+        dht_hash_func     hash_func = nullptr);
 
     size_t size() const {return reccnt;}
-    std::string calc_bucket_id(ucharptr_c key);
     bool search(ucharptr_c key, ucharptr val = nullptr);
     bool insert(ucharptr_c key, ucharptr_c val = nullptr);
     bool append(ucharptr_c key, ucharptr_c val = nullptr);
@@ -77,8 +80,11 @@ public:
     static std::string get_bucket_fspec(const std::string path, const std::string base, const std::string bucket);
 
 private:
+    std::string calc_bucket_id(ucharptr_c key);
     BucketFile* get_bucket(const std::string& bucket);
     std::string get_bucket_fspec(const std::string& bucket);
+
+    static std::string default_hasher(ucharptr_c key, size_t keylen);
 };
 
 

--- a/dht.h
+++ b/dht.h
@@ -23,7 +23,7 @@
 typedef unsigned char * ucharptr;
 typedef const ucharptr  ucharptr_c;
 
-typedef std::string (*dht_hash_func)(ucharptr_c, size_t);
+typedef std::string (*dht_bucket_id_func)(ucharptr_c, size_t);
 
 struct BucketFile
 {
@@ -56,7 +56,7 @@ private:
     std::string                        path;
     std::string                        name;
     size_t                             reccnt;
-    dht_hash_func                      hashfunc;
+    dht_bucket_id_func                 buckfunc;
 
 public:
     DiskHashTable();
@@ -64,12 +64,12 @@ public:
     virtual ~DiskHashTable();
 
     bool open(
-        const std::string path_name,
-        const std::string base_name,
-        int               level,
-        size_t            key_len,
-        size_t            val_len = 0,
-        dht_hash_func     hash_func = nullptr);
+        const std::string  path_name,
+        const std::string  base_name,
+        int                level,
+        size_t             key_len,
+        size_t             val_len = 0,
+        dht_bucket_id_func bucket_func = nullptr);
 
     size_t size() const {return reccnt;}
     bool search(ucharptr_c key, ucharptr val = nullptr);


### PR DESCRIPTION
Defined a function pointer type as:

`std::string (*dht_bucket_id_func)(ucharptr_c, size_t)`

The answer of which should be a two-hex-digit string indicating the bucket id.